### PR TITLE
Fix for issue #62 & #59

### DIFF
--- a/KeePassHttp/Properties/AssemblyInfo.cs
+++ b/KeePassHttp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.20.1.0")]
 [assembly: AssemblyFileVersion("1.0.6.1")]


### PR DESCRIPTION
I had to change the AssemblyVersion in Properties/AssemblyInfo.cs so that it matched the latest KeePass.exe from http://keepass.info.

This resolved my "Incompatible" errors with Mono on Linux.
