### PR TITLE
Add null check to MainNotifyIcon

### DIFF
--- a/KeePassHttp/KeePassHttp.cs
+++ b/KeePassHttp/KeePassHttp.cs
@@ -139,6 +139,8 @@ namespace KeePassHttp
             MethodInvoker m = delegate
             {
                 var notify = host.MainWindow.MainNotifyIcon;
+                if (notify == null)
+                    return;
 
                 EventHandler clicked = null;
                 EventHandler closed = null;


### PR DESCRIPTION
fixes dlech/Keebuntu#16

I have an addon that completely disables the Winforms tray icon and replaces it with a native application indicator. The only way I could disable it was to make it null (and I tried many other ways first). So, when users use both addons, KeePassHTTP crashes because of this.

So hopefully you will accept this change so that both addons can live happily together.
