### PR TITLE
Fixed exception System.ArgumentOutOfRangeException: Index was out of range

### DIFF
--- a/KeePassHttp/Handlers.cs
+++ b/KeePassHttp/Handlers.cs
@@ -350,7 +350,9 @@ namespace KeePassHttp {
                                  orderby e.entry.UsageCount ascending 
                                  select e).ToList();
 
-                    ulong lowestDistance = itemsList[0].entry.UsageCount;
+                    ulong lowestDistance = itemsList.Count > 0 ?
+                        itemsList[0].entry.UsageCount :
+                        0;
 
                     itemsList = (from e in itemsList
                                  where e.entry.UsageCount == lowestDistance


### PR DESCRIPTION
When user being asked to allow or deny access to password, and user
denies access – there will be no items in itemList and will be exception
thrown. It was fixed.