### PR TITLE
Center access prompt on screen if KeePass main window is minimized.

### DIFF
--- a/KeePassHttp/Handlers.cs
+++ b/KeePassHttp/Handlers.cs
@@ -310,6 +310,7 @@ namespace KeePassHttp {
                         {
                             f.Icon = win.Icon;
                             f.Plugin = this;
+                            f.StartPosition = win.Visible ? FormStartPosition.CenterParent : FormStartPosition.CenterScreen;
                             f.Entries = (from e in items where filter(e.entry) select e.entry).ToList();
                             //f.Entries = needPrompting.ToList();
                             f.Host = submithost != null ? submithost : host;


### PR DESCRIPTION
If the KeePass main window is invisible (=minimized), the access prompt is placed at the top-left corner of the screen. On large screens, it may go unnoticed, confusing the user. Instead, center it on the screen in this situation.