### PR TITLE
Switch update URL to GitHub

### DIFF
--- a/KeePassHttp/KeePassHttp.cs
+++ b/KeePassHttp/KeePassHttp.cs
@@ -55,7 +55,7 @@ namespace KeePassHttp
         Dictionary<string, RequestHandler> handlers = new Dictionary<string, RequestHandler>();
 
         //public string UpdateUrl = "";
-        public override string UpdateUrl { get { return "https://passifox.appspot.com/kph/latest-version.txt"; } }
+        public override string UpdateUrl { get { return "https://raw.githubusercontent.com/pfn/keepasshttp/master/latest-version.txt"; } }
 
         private SearchParameters MakeSearchParameters()
         {


### PR DESCRIPTION
This fixes issue #403. The plugin update URL is changed to [`https://raw.githubusercontent.com/pfn/keepasshttp/master/latest-version.txt`](https://raw.githubusercontent.com/pfn/keepasshttp/master/latest-version.txt) instead of the broken URL [`https://passifox.appspot.com/kph/latest-version.txt`](https://passifox.appspot.com/kph/latest-version.txt) that currently gives an HTTP 500 error.

A .plgx file incorporating this fix can be downloaded from [my fork](https://github.com/ihanson/keepasshttp/releases/tag/1.8.4.2a).